### PR TITLE
fix: address heatmap gradient bug and timezone-aware sun phases

### DIFF
--- a/shared/types.ts
+++ b/shared/types.ts
@@ -5,7 +5,10 @@ export interface AudioMothMeta {
   gain: string;
   batteryV: number | null;
   temperatureC: number | null;
-  recordedAtUtc: string | null;
+  /** ISO 8601 recording timestamp. Includes 'Z' for UTC or '+HH:MM'/'-HH:MM' offset. */
+  recordedAt: string | null;
+  /** UTC offset in minutes parsed from the AudioMoth comment (0 = UTC, null = unknown). */
+  timezoneOffsetMin: number | null;
 }
 
 export interface AudioFileInfo {
@@ -47,6 +50,8 @@ export interface AnalysisRun {
   status: 'pending' | 'running' | 'completed' | 'failed';
   started_at: string | null;
   completed_at: string | null;
+  /** UTC offset in minutes of the recording's timezone (0 = UTC, null = unknown). */
+  timezone_offset_min: number | null;
 }
 
 export interface RunWithStats extends AnalysisRun {
@@ -118,6 +123,8 @@ export interface AnalysisRequest {
   location_name?: string | undefined;
   month?: number | undefined;
   day?: number | undefined;
+  /** UTC offset in minutes from AudioMoth metadata (0 = UTC). Omit if unknown. */
+  timezone_offset_min?: number | undefined;
 }
 
 export interface DetectionFilter {

--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -87,6 +87,17 @@ function runMigrations(db: Database.Database): void {
       db.prepare('INSERT INTO schema_migrations (version) VALUES (?)').run(2);
     })();
   }
+
+  // Migration 3: Add timezone_offset_min to analysis_runs
+  if (!applied.has(3)) {
+    db.transaction(() => {
+      const columns = db.prepare('PRAGMA table_info(analysis_runs)').all() as { name: string }[];
+      if (!columns.some((c) => c.name === 'timezone_offset_min')) {
+        db.exec('ALTER TABLE analysis_runs ADD COLUMN timezone_offset_min INTEGER');
+      }
+      db.prepare('INSERT INTO schema_migrations (version) VALUES (?)').run(3);
+    })();
+  }
 }
 
 export function clearDatabase(): { detections: number; runs: number; locations: number } {

--- a/src/main/db/runs.ts
+++ b/src/main/db/runs.ts
@@ -7,13 +7,21 @@ export function createRun(
   minConfidence: number,
   locationId?: number | null,
   settingsJson?: string | null,
+  timezoneOffsetMin?: number | null,
 ): AnalysisRun {
   const db = getDb();
   const stmt = db.prepare(`
-    INSERT INTO analysis_runs (location_id, source_path, model, min_confidence, settings_json, status, started_at)
-    VALUES (?, ?, ?, ?, ?, 'running', datetime('now'))
+    INSERT INTO analysis_runs (location_id, source_path, model, min_confidence, settings_json, timezone_offset_min, status, started_at)
+    VALUES (?, ?, ?, ?, ?, ?, 'running', datetime('now'))
   `);
-  const result = stmt.run(locationId ?? null, sourcePath, model, minConfidence, settingsJson ?? null);
+  const result = stmt.run(
+    locationId ?? null,
+    sourcePath,
+    model,
+    minConfidence,
+    settingsJson ?? null,
+    timezoneOffsetMin ?? null,
+  );
   return getRunById(result.lastInsertRowid as number)!;
 }
 

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -9,16 +9,17 @@ CREATE TABLE IF NOT EXISTS locations (
 );
 
 CREATE TABLE IF NOT EXISTS analysis_runs (
-    id              INTEGER PRIMARY KEY AUTOINCREMENT,
-    location_id     INTEGER REFERENCES locations(id),
-    source_path     TEXT NOT NULL,
-    model           TEXT NOT NULL,
-    min_confidence  REAL NOT NULL DEFAULT 0.1,
-    settings_json   TEXT,
-    status          TEXT NOT NULL DEFAULT 'pending'
-                    CHECK (status IN ('pending','running','completed','failed')),
-    started_at      TEXT,
-    completed_at    TEXT
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    location_id         INTEGER REFERENCES locations(id),
+    source_path         TEXT NOT NULL,
+    model               TEXT NOT NULL,
+    min_confidence      REAL NOT NULL DEFAULT 0.1,
+    settings_json       TEXT,
+    status              TEXT NOT NULL DEFAULT 'pending'
+                        CHECK (status IN ('pending','running','completed','failed')),
+    started_at          TEXT,
+    completed_at        TEXT,
+    timezone_offset_min INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS detections (

--- a/src/main/ipc/analysis.ts
+++ b/src/main/ipc/analysis.ts
@@ -60,7 +60,14 @@ export function registerAnalysisHandlers(): void {
     }
 
     // Create run record
-    const run = createRun(request.source_path, request.model, request.min_confidence, locationId);
+    const run = createRun(
+      request.source_path,
+      request.model,
+      request.min_confidence,
+      locationId,
+      undefined,
+      request.timezone_offset_min,
+    );
     sendLog(win, 'info', 'analysis', `Created analysis run: id=${run.id}`);
 
     // Resolve month/day: prefer values from request, then try to parse from filename

--- a/src/renderer/src/App.svelte
+++ b/src/renderer/src/App.svelte
@@ -73,6 +73,7 @@
     longitude: number;
     month?: number | undefined;
     day?: number | undefined;
+    timezoneOffsetMin?: number | undefined;
   }) {
     if (!appState.sourcePath) return;
 
@@ -93,6 +94,7 @@
         location_name: opts.locationName || undefined,
         month: opts.month,
         day: opts.day,
+        timezone_offset_min: opts.timezoneOffsetMin,
       });
       analysisState.status = 'completed';
       appState.lastRunId = result.runId;

--- a/src/renderer/src/lib/components/SourceFilesPanel.svelte
+++ b/src/renderer/src/lib/components/SourceFilesPanel.svelte
@@ -113,9 +113,9 @@
             >
           </div>
         {/if}
-        {#if file.audiomoth?.recordedAtUtc ?? parseRecordingStart(file.name)}
-          {@const isUtc = !!file.audiomoth?.recordedAtUtc}
-          {@const recStart = isUtc ? new Date(file.audiomoth!.recordedAtUtc!) : parseRecordingStart(file.name)!}
+        {#if file.audiomoth?.recordedAt ?? parseRecordingStart(file.name)}
+          {@const isUtc = file.audiomoth?.timezoneOffsetMin === 0}
+          {@const recStart = isUtc ? new Date(file.audiomoth!.recordedAt!) : parseRecordingStart(file.name)!}
           {@const tzOpt = isUtc ? { timeZone: 'UTC' as const } : undefined}
           <div class="flex items-center gap-2">
             <Calendar size={14} class="text-base-content/40" />

--- a/src/renderer/src/pages/AnalysisPage.svelte
+++ b/src/renderer/src/pages/AnalysisPage.svelte
@@ -40,6 +40,7 @@
       longitude: number;
       month?: number | undefined;
       day?: number | undefined;
+      timezoneOffsetMin?: number | undefined;
     }) => void;
     onstop: () => void;
   } = $props();
@@ -299,7 +300,9 @@
       month = d.getMonth() + 1;
       day = d.getDate();
     }
-    onstart({ locationName, latitude, longitude, month, day });
+    // Extract timezone offset from AudioMoth metadata of the first scanned file
+    const timezoneOffsetMin = scanResult?.files[0]?.audiomoth?.timezoneOffsetMin ?? undefined;
+    onstart({ locationName, latitude, longitude, month, day, timezoneOffsetMin });
   }
 
   async function handleOpenFile() {

--- a/src/renderer/src/pages/DetectionsPage.svelte
+++ b/src/renderer/src/pages/DetectionsPage.svelte
@@ -451,6 +451,7 @@
           latitude={selectedRun.latitude}
           longitude={selectedRun.longitude}
           recordingDate={recordingStart}
+          timezoneOffsetMin={selectedRun.timezone_offset_min}
         />
       {/if}
     </div>


### PR DESCRIPTION
## Summary

Addresses two code review comments from PR #8 that were missed before merge:

- **Gradient bug (Gemini):** Sunrise/sunset CSS gradients were missing terminal phase colors — sunrise ended abruptly at amber without transitioning to daylight, sunset started at rose without coming from daylight. Both now include all 4 color stops. Extracted magic number `15` into `GRADIENT_BAND_HALFWIDTH_PCT` constant.

- **Timezone handling (Sentry):** `computeHourlySunPhases()` assumed UTC for all recordings, but AudioMoth can record in either UTC or local time depending on user configuration. The timezone offset is now parsed from AudioMoth metadata comments (supports `(UTC)`, `(UTC+3)`, `(UTC-5:30)`, etc.), stored in `analysis_runs`, and used to convert heatmap "filename hours" to real UTC times for accurate sun position calculation.

### Changes

| File | Change |
|------|--------|
| `shared/types.ts` | Add `timezoneOffsetMin` to `AudioMothMeta`, `timezone_offset_min` to `AnalysisRun` + `AnalysisRequest` |
| `src/main/ipc/files.ts` | Parse timezone offset from AudioMoth comment; rename `recordedAtUtc` → `recordedAt` |
| `src/main/db/schema.ts` | Add `timezone_offset_min` column to `analysis_runs` |
| `src/main/db/database.ts` | Migration 3: add column to existing databases |
| `src/main/db/runs.ts` | Accept and store timezone offset in `createRun()` |
| `src/main/ipc/analysis.ts` | Pass timezone offset to `createRun()` |
| `src/renderer/src/pages/AnalysisPage.svelte` | Extract timezone from scan results, pass through `onstart` |
| `src/renderer/src/App.svelte` | Forward timezone to `startAnalysis()` request |
| `src/renderer/src/lib/utils/sun.ts` | Accept `timezoneOffsetMin` param, use local date accessors, adjust UTC times |
| `src/renderer/src/lib/components/DetectionHeatmap.svelte` | Accept + pass timezone offset; fix gradient stops; add constant |
| `src/renderer/src/pages/DetectionsPage.svelte` | Pass `timezone_offset_min` to heatmap |
| `src/renderer/src/lib/components/SourceFilesPanel.svelte` | Update for renamed `recordedAt` field |

## Test plan

- [ ] Run analysis with an AudioMoth UTC recording → verify sun phases align with heatmap hours
- [ ] Run analysis with an AudioMoth local-time recording (UTC+N) → verify sun phases are shifted correctly
- [ ] Run analysis with a non-AudioMoth recording (no metadata) → verify fallback to UTC offset (0)
- [ ] Verify sunrise gradient transitions: twilight → orange → amber → daylight
- [ ] Verify sunset gradient transitions: daylight → rose → purple → twilight
- [ ] Verify existing runs without `timezone_offset_min` still work (null → defaults to 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added timezone offset support for audio file metadata to enable accurate location-based analysis
  * Detection heatmap now calculates sun phases using the recording's local timezone instead of UTC
  * Timezone information is automatically extracted from audio files and stored with analysis runs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->