### PR TITLE
fix: correct timestamp pattern in Italian translation

### DIFF
--- a/messages/it.json
+++ b/messages/it.json
@@ -367,7 +367,7 @@
   "grid_phase_night": "Notte",
   "grid_phase_twilight": "Crepuscolo",
   "grid_phase_daylight": "Luce diurna",
-  "grid_noTimestamp": "La griglia oraria richiede una registrazione con timestamp (AAAAMMGG_HHMMSS)",
+  "grid_noTimestamp": "La griglia oraria richiede una registrazione con timestamp (YYYYMMDD_HHMMSS)",
   "grid_detectionCount": "{count} rilevamenti",
   "grid_detectionCountSingular": "{count} rilevamento",
   "grid_less": "Meno",


### PR DESCRIPTION
## Issue

The Italian translation incorrectly translated the filename timestamp pattern `YYYYMMDD_HHMMSS` to `AAAAMMGG_HHMMSS`. 

## Problem

The pattern `YYYYMMDD_HHMMSS` describes an **actual filename convention on disk** (e.g., `20260215_143000.wav`). Users need to recognize and match this exact pattern to understand which files have timestamps. This is not a UI label that should be localized - it's a technical filename format specification.

## Fix

Changed Italian translation back from:
```
AAAAMMGG_HHMMSS
```

to:
```
YYYYMMDD_HHMMSS
```

## Validation

The French translation correctly kept the original `YYYYMMDD_HHMMSS` format:
```json
"grid_noTimestamp": "La grille horaire nécessite un enregistrement horodaté (YYYYMMDD_HHMMSS)"
```

This follows the same pattern as other technical specifications that should not be translated (like file formats WAV, MP3, etc.).

## Files Changed
- `messages/it.json`: Fixed timestamp pattern in `grid_noTimestamp` key