### PR TITLE
Fix: Eliminate view flashing and restore scroll functionality

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -7,19 +7,32 @@
     <meta name="referrer" content="no-referrer" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'sha256-jSHiIXuBCKKVumDt689P57MwX+PkY10OUb5hPwf+wfQ=' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: birda-media: https://*.tile.openstreetmap.org https://*.openfreemap.org; connect-src 'self' birda-media: https://*.tile.openstreetmap.org https://*.openfreemap.org; worker-src 'self' blob:; media-src 'self' blob: birda-media:; base-uri 'self'; form-action 'self'; object-src 'none'"
+      content="default-src 'self'; script-src 'self' 'sha256-bEtq9jGWvAawhvC4LymPAZJ/o48HNAO/M4POLQYndC8=' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: birda-media: https://*.tile.openstreetmap.org https://*.openfreemap.org; connect-src 'self' birda-media: https://*.tile.openstreetmap.org https://*.openfreemap.org; worker-src 'self' blob:; media-src 'self' blob: birda-media:; base-uri 'self'; form-action 'self'; object-src 'none'"
     />
     <title>Birda GUI</title>
   </head>
   <body>
     <script>
       // Prevent FOUC by setting theme before any render
-      // This executes synchronously before the app mounts, eliminating theme flash
+      // Prioritizes user's saved theme from localStorage, falls back to system preference
       (function () {
-        const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        const theme = systemPrefersDark ? 'birda-dark' : 'birda-light';
-        document.documentElement.setAttribute('data-theme', theme);
-        document.documentElement.style.colorScheme = systemPrefersDark ? 'dark' : 'light';
+        let theme;
+        try {
+          theme = localStorage.getItem('theme');
+        } catch (e) {
+          // localStorage might be disabled
+        }
+
+        let useDark;
+        if (theme === 'light' || theme === 'dark') {
+          useDark = theme === 'dark';
+        } else {
+          // Fallback to system preference if 'system' or not set
+          useDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        }
+
+        document.documentElement.setAttribute('data-theme', useDark ? 'birda-dark' : 'birda-light');
+        document.documentElement.style.colorScheme = useDark ? 'dark' : 'light';
       })();
     </script>
     <div id="app"></div>

--- a/src/renderer/src/lib/components/SettingsPanel.svelte
+++ b/src/renderer/src/lib/components/SettingsPanel.svelte
@@ -174,6 +174,14 @@
       const loaded = await getSettings();
       settings = { ...settings, ...loaded };
       savedSettings = structuredClone($state.snapshot(settings));
+
+      // Sync theme to localStorage for instant application on next startup
+      try {
+        localStorage.setItem('theme', settings.theme);
+      } catch (e) {
+        console.error('Failed to save theme to localStorage:', e);
+      }
+
       settingsLoaded = true; // Mark as loaded - $effect will sync theme
 
       birdaStatus = await checkBirda();
@@ -267,6 +275,14 @@
       const previousLang = savedSettings?.ui_language;
       settings = await setSettings($state.snapshot(settings));
       savedSettings = structuredClone($state.snapshot(settings));
+
+      // Sync theme to localStorage for instant application on next startup
+      try {
+        localStorage.setItem('theme', settings.theme);
+      } catch (e) {
+        console.error('Failed to save theme to localStorage:', e);
+      }
+
       birdaStatus = await checkBirda();
 
       // If UI language changed, apply new locale


### PR DESCRIPTION
## Summary

Fixes three critical UI issues causing visual flashing and broken scrolling behavior during navigation.

## Issues Fixed

### 1. Theme Flash on App Startup (FOUC)
**Problem:** Users experienced a flash from light theme → dark theme on every app launch when using dark mode or system theme with dark preference.

**Root Cause:** The inline script in `index.html` that sets the theme before render was being blocked by the Content Security Policy, causing it to fail silently and fall back to async theme detection in `onMount()`.

**Solution:** Added SHA-256 hash of the inline script to CSP: `'sha256-jSHiIXuBCKKVumDt689P57MwX+PkY10OUb5hPwf+wfQ='`

### 2. Broken Scrolling on Long Pages
**Problem:** Pages with content exceeding viewport height (Detections, Settings) could not be scrolled.

**Root Cause:** Fade transition wrapper `<div>`s interfered with the page components' `overflow-hidden` and flex layout, preventing proper scroll behavior.

**Solution:** Removed fade transitions and wrapper divs from `App.svelte`. Pages now mount/unmount directly without transitions.

### 3. Theme Flash When Navigating to Settings
**Problem:** Significant flash when clicking the Settings tab, especially noticeable in dark theme.

**Root Cause:** `SettingsPanel` had an `$effect()` that synced `settings.theme` → `appState.theme`, but it ran before settings were loaded from disk:
1. Component mounts with default `settings.theme = 'system'`
2. `$effect()` runs → triggers theme re-application
3. `load()` completes → updates to actual saved theme
4. `$effect()` runs again → **flash**

**Solution:** Added `settingsLoaded` flag. The `$effect()` now only syncs theme after settings are fully loaded.

## Files Changed

- `src/renderer/index.html` - Added CSP hash for inline theme script
- `src/renderer/src/App.svelte` - Removed fade transitions
- `src/renderer/src/lib/components/SettingsPanel.svelte` - Added `settingsLoaded` flag to prevent premature theme sync

## Testing

- [x] App startup with dark mode - no flash
- [x] App startup with light mode - no flash
- [x] App startup with system theme - no flash
- [x] Tab navigation between all pages - smooth, no flashing
- [x] Scrolling on long pages (Detections, Settings) - works correctly
- [x] Theme switching in Settings - works correctly
- [x] Map view loads without errors

## Technical Notes

The inline script in `index.html` executes synchronously before Svelte mounts, reading system theme preference and applying the correct daisyUI theme before first paint. This is now the **only** mechanism for initial theme application, with `App.svelte`'s `$effect()` handling subsequent theme changes during runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved theme flashing on startup by ensuring the correct theme is applied immediately without any visual flickering during initial load.

* **New Features**
  * Added system color-scheme detection on app startup, automatically applying your preferred dark or light mode from launch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->