### PR TITLE
Fix: Enable birda binary selection on non-Windows platforms

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -277,7 +277,7 @@
   "wizard_cli_checking": "Suche nach birda...",
   "wizard_cli_found": "birda gefunden unter {path}",
   "wizard_cli_notFound": "birda wurde auf Ihrem System nicht gefunden.",
-  "wizard_cli_notFoundHint": "birda sollte automatisch installiert worden sein. Sie können den Pfad manuell festlegen oder es herunterladen.",
+  "wizard_cli_notFoundHint": "Sie können den Pfad manuell festlegen, falls birda installiert ist, oder es über den Link unten herunterladen.",
   "wizard_cli_download": "birda Herunterladen",
   "wizard_cli_setPath": "Pfad manuell festlegen",
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -278,7 +278,7 @@
   "wizard_cli_checking": "Checking for birda...",
   "wizard_cli_found": "birda found at {path}",
   "wizard_cli_notFound": "birda was not found on your system.",
-  "wizard_cli_notFoundHint": "birda should have been installed automatically. You can set the path manually or download it.",
+  "wizard_cli_notFoundHint": "You can set the path manually if birda is installed, or download it from the link below.",
   "wizard_cli_download": "Download birda",
   "wizard_cli_setPath": "Set path manually",
 

--- a/messages/es.json
+++ b/messages/es.json
@@ -278,7 +278,7 @@
   "wizard_cli_checking": "Buscando birda...",
   "wizard_cli_found": "birda encontrado en {path}",
   "wizard_cli_notFound": "birda no se encontró en tu sistema.",
-  "wizard_cli_notFoundHint": "birda debería haberse instalado automáticamente. Puedes establecer la ruta manualmente o descargarlo.",
+  "wizard_cli_notFoundHint": "Puedes establecer la ruta manualmente si birda está instalado, o descargarlo desde el enlace de abajo.",
   "wizard_cli_download": "Descargar birda",
   "wizard_cli_setPath": "Establecer ruta manualmente",
 

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -277,7 +277,7 @@
   "wizard_cli_checking": "Tarkistetaan birda-työkalua...",
   "wizard_cli_found": "birda löytyi polusta {path}",
   "wizard_cli_notFound": "birda-työkalua ei löytynyt järjestelmästäsi.",
-  "wizard_cli_notFoundHint": "birda olisi pitänyt asentua automaattisesti. Voit asettaa polun manuaalisesti tai ladata sen.",
+  "wizard_cli_notFoundHint": "Voit asettaa polun manuaalisesti, jos birda on asennettu, tai ladata sen alla olevasta linkistä.",
   "wizard_cli_download": "Lataa birda",
   "wizard_cli_setPath": "Aseta polku manuaalisesti",
 

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -278,7 +278,7 @@
   "wizard_cli_checking": "Recherche de birda...",
   "wizard_cli_found": "birda trouvé à {path}",
   "wizard_cli_notFound": "birda n'a pas été trouvé sur ton système.",
-  "wizard_cli_notFoundHint": "birda aurait dû être installé automatiquement. Tu peux définir le chemin manuellement ou le télécharger.",
+  "wizard_cli_notFoundHint": "Tu peux définir le chemin manuellement si birda est installé, ou le télécharger via le lien ci-dessous.",
   "wizard_cli_download": "Télécharger birda",
   "wizard_cli_setPath": "Définir le chemin manuellement",
 

--- a/messages/it.json
+++ b/messages/it.json
@@ -278,7 +278,7 @@
   "wizard_cli_checking": "Ricerca di birda...",
   "wizard_cli_found": "birda trovato in {path}",
   "wizard_cli_notFound": "birda non è stato trovato sul tuo sistema.",
-  "wizard_cli_notFoundHint": "birda avrebbe dovuto essere installato automaticamente. Puoi impostare il percorso manualmente o scaricarlo.",
+  "wizard_cli_notFoundHint": "Puoi impostare il percorso manualmente se birda è installato, o scaricarlo dal link qui sotto.",
   "wizard_cli_download": "Scarica birda",
   "wizard_cli_setPath": "Imposta percorso manualmente",
 

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -278,7 +278,7 @@
   "wizard_cli_checking": "Controleren op birda...",
   "wizard_cli_found": "birda gevonden op {path}",
   "wizard_cli_notFound": "birda is niet gevonden op je systeem.",
-  "wizard_cli_notFoundHint": "birda had automatisch geïnstalleerd moeten worden. Je kunt het pad handmatig instellen of downloaden.",
+  "wizard_cli_notFoundHint": "Je kunt het pad handmatig instellen als birda is geïnstalleerd, of het downloaden via de onderstaande link.",
   "wizard_cli_download": "birda downloaden",
   "wizard_cli_setPath": "Pad handmatig instellen",
 

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -278,7 +278,7 @@
   "wizard_cli_checking": "Sprawdzam birda...",
   "wizard_cli_found": "birda znaleziony w {path}",
   "wizard_cli_notFound": "birda nie został znaleziony w systemie.",
-  "wizard_cli_notFoundHint": "birda powinien zostać zainstalowany automatycznie. Możesz ustawić ścieżkę ręcznie lub pobrać go.",
+  "wizard_cli_notFoundHint": "Możesz ustawić ścieżkę ręcznie, jeśli birda jest zainstalowany, lub pobrać go z linku poniżej.",
   "wizard_cli_download": "Pobierz birda",
   "wizard_cli_setPath": "Ustaw ścieżkę ręcznie",
 

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -278,7 +278,7 @@
   "wizard_cli_checking": "A verificar o birda...",
   "wizard_cli_found": "birda encontrado em {path}",
   "wizard_cli_notFound": "O birda não foi encontrado no teu sistema.",
-  "wizard_cli_notFoundHint": "O birda deveria ter sido instalado automaticamente. Podes definir o caminho manualmente ou fazer o download.",
+  "wizard_cli_notFoundHint": "Podes definir o caminho manualmente se o birda estiver instalado, ou fazer o download através do link abaixo.",
   "wizard_cli_download": "Fazer download do birda",
   "wizard_cli_setPath": "Definir caminho manualmente",
 

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -277,7 +277,7 @@
   "wizard_cli_checking": "Letar efter birda...",
   "wizard_cli_found": "birda hittades vid {path}",
   "wizard_cli_notFound": "birda hittades inte på ditt system.",
-  "wizard_cli_notFoundHint": "birda borde ha installerats automatiskt. Du kan ange sökvägen manuellt eller ladda ner den.",
+  "wizard_cli_notFoundHint": "Du kan ange sökvägen manuellt om birda är installerad, eller ladda ner den via länken nedan.",
   "wizard_cli_download": "Ladda ner birda",
   "wizard_cli_setPath": "Ange sökväg manuellt",
 

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -148,12 +148,18 @@ export async function registerSettingsHandlers(): Promise<void> {
   });
 
   ipcMain.handle('fs:open-executable-dialog', async (_event) => {
+    // Platform-specific file filters for executables
+    const filters =
+      process.platform === 'win32'
+        ? [
+            { name: 'Executables', extensions: ['exe', 'cmd', 'bat'] },
+            { name: 'All Files', extensions: ['*'] },
+          ]
+        : [{ name: 'All Files', extensions: ['*'] }];
+
     const result = await dialog.showOpenDialog({
       properties: ['openFile'],
-      filters: [
-        { name: 'Executables', extensions: ['exe', 'cmd', 'bat', ''] },
-        { name: 'All Files', extensions: ['*'] },
-      ],
+      filters,
     });
     return result.canceled ? null : result.filePaths[0];
   });


### PR DESCRIPTION
## Summary
Fixes two issues in the first-time setup wizard:
- File picker now works correctly on Linux/macOS
- Corrected misleading message about automatic birda installation

## Changes

### 1. Platform-aware file picker ([src/main/ipc/settings.ts:150-164](src/main/ipc/settings.ts#L150-L164))
The `openExecutableDialog` handler now detects the platform:
- **Windows**: Filters for `.exe`, `.cmd`, `.bat` extensions
- **Linux/macOS**: Shows all files (executables don't have extensions)

Previously, the dialog was hardcoded to Windows extensions, preventing users on non-Windows systems from selecting the birda binary.

### 2. Fixed misleading wizard message
Updated `wizard_cli_notFoundHint` in all 10 language files:
- **Old**: "birda should have been installed automatically..."
- **New**: "You can set the path manually if birda is installed, or download it from the link below."

The birda CLI requires separate installation and is not bundled with the GUI.

## Test plan
- [ ] On Linux/macOS, open the setup wizard
- [ ] Verify the file picker allows selecting any file (not just .exe)
- [ ] Verify the wizard message no longer mentions automatic installation
- [ ] Test in multiple UI languages

## Testing checklist
- [ ] File picker works on Linux
- [ ] File picker works on macOS  
- [ ] File picker still works on Windows
- [ ] All language translations are correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated CLI tool not-found guidance message across all languages to clarify manual path configuration and download options.
  * Improved Windows file dialog filtering for executable selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->