### PR TITLE
Add loading spinner during initial settings load

### DIFF
--- a/src/renderer/src/App.svelte
+++ b/src/renderer/src/App.svelte
@@ -199,7 +199,7 @@
 
 {#if showWizard === null}
   <main class="bg-base-100 flex h-screen items-center justify-center select-none">
-    <span class="loading loading-spinner loading-lg text-primary"></span>
+    <span class="loading loading-spinner loading-lg text-primary" role="status" aria-label="Loading"></span>
   </main>
 {:else if showWizard}
   <main class="bg-base-100 text-base-content h-screen select-none">


### PR DESCRIPTION
## Summary
- Replace blank screen with a centered daisyUI loading spinner while settings load asynchronously on startup
- Add `role="status"` and `aria-label` for screen reader accessibility

## Test Plan
- [ ] Visual check: spinner appears briefly on launch, then transitions to wizard or main app
- [ ] Verify spinner is centered on screen
- [ ] Screen reader announces loading state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Application now displays a centered loading spinner during initialization instead of showing a blank screen, providing improved visual feedback during the loading phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->