### PR TITLE
Display dynamic app version in StatusBar

### DIFF
--- a/src/main/ipc/system.ts
+++ b/src/main/ipc/system.ts
@@ -11,4 +11,8 @@ export function registerSystemHandlers(): void {
   ipcMain.handle('system:get-locale', () => {
     return app.getLocale();
   });
+
+  ipcMain.handle('app:get-version', () => {
+    return app.getVersion();
+  });
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -48,6 +48,7 @@ const ALLOWED_INVOKE_CHANNELS = new Set([
   'app:get-licenses',
   'gpu:detect-capabilities',
   'system:get-locale',
+  'app:get-version',
 ]);
 
 const ALLOWED_RECEIVE_CHANNELS = new Set([

--- a/src/renderer/src/lib/components/StatusBar.svelte
+++ b/src/renderer/src/lib/components/StatusBar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { appState } from '$lib/stores/app.svelte';
   import { formatNumber } from '$lib/utils/format';
-  import { checkBirda } from '$lib/utils/ipc';
+  import { checkBirda, getAppVersion } from '$lib/utils/ipc';
   import type { BirdaCheckResponse } from '$shared/types';
   import { BIRDA_RELEASES_URL } from '$shared/constants';
   import { TriangleAlert, ExternalLink } from '@lucide/svelte';
@@ -11,6 +11,7 @@
 
   let birdaStatus = $state<BirdaCheckResponse | null>(null);
   let showVersionModal = $state(false);
+  let appVersion = $state('');
 
   const isOutdated = $derived(birdaStatus && !birdaStatus.available && birdaStatus.version && birdaStatus.minVersion);
 
@@ -23,6 +24,18 @@
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (mounted) {
           birdaStatus = result;
+        }
+      } catch {
+        // Silent fail - status bar is not critical
+      }
+    })();
+
+    void (async () => {
+      try {
+        const version = await getAppVersion();
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        if (mounted) {
+          appVersion = version;
         }
       } catch {
         // Silent fail - status bar is not critical
@@ -68,7 +81,7 @@
     <div class="bg-base-300 h-3 w-px"></div>
   {/if}
 
-  <span>v1.0.0</span>
+  {#if appVersion}<span>v{appVersion}</span>{/if}
 </div>
 
 <!-- Birda Version Update Modal -->

--- a/src/renderer/src/lib/utils/ipc.ts
+++ b/src/renderer/src/lib/utils/ipc.ts
@@ -285,3 +285,7 @@ export function saveSpectrogram(clipPath: string, freqMax: number, height: numbe
 export function getSystemLocale(): Promise<string> {
   return window.birda.invoke('system:get-locale') as Promise<string>;
 }
+
+export function getAppVersion(): Promise<string> {
+  return window.birda.invoke('app:get-version') as Promise<string>;
+}


### PR DESCRIPTION
## Summary
- Replace hardcoded `v1.0.0` in StatusBar with version from `app.getVersion()` via IPC
- Adds `app:get-version` IPC channel following existing architecture patterns (handler → preload allowlist → typed wrapper → component)
- Version now stays in sync with `package.json` across releases

## Changes
- `src/main/ipc/system.ts` — New `app:get-version` handler using Electron's `app.getVersion()`
- `src/preload/index.ts` — Added channel to `ALLOWED_INVOKE_CHANNELS`
- `src/renderer/src/lib/utils/ipc.ts` — Added `getAppVersion()` typed wrapper
- `src/renderer/src/lib/components/StatusBar.svelte` — Fetches version on mount, displays dynamically

## Test plan
- [ ] StatusBar displays version matching `package.json` (currently `1.1.0`)
- [ ] Bump version in `package.json`, rebuild — StatusBar reflects new version
- [ ] Version area is empty/hidden if IPC call fails (graceful degradation)