### PR TITLE
Keep expensive tab pages alive across tab switches

### DIFF
--- a/src/renderer/src/App.svelte
+++ b/src/renderer/src/App.svelte
@@ -44,8 +44,8 @@
 
   $effect(() => {
     const tab = appState.activeTab;
-    if (tab === 'detections' || tab === 'map' || tab === 'species') {
-      visited[tab] = true;
+    if (tab in visited) {
+      visited[tab as keyof typeof visited] = true;
     }
   });
 


### PR DESCRIPTION
## Summary

- Replace `{#if}/{:else if}` conditional rendering in `App.svelte` with a **lazy keep-alive** pattern for expensive pages (DetectionsPage, MapPage, SpeciesPage)
- Pages mount on first visit and remain in the DOM with CSS visibility toggling (`class:hidden`), preserving scroll position, filter state, and MapLibre GL context
- AnalysisPage and SettingsPage remain conditionally rendered (cheap to recreate)

## What changed

**`src/renderer/src/App.svelte`:**
- Added `visited` state object tracking which expensive tabs have been opened
- `$effect` sets `visited[tab] = true` on first visit (one-way ratchet)
- Template uses `{#if visited.X}` + `class:hidden` for lazy keep-alive
- Analysis and Settings tabs remain `{#if}`/`{:else if}` (destroyed on switch)

## Why lazy keep-alive instead of always-mounted

Code review (both manual and Gemini-assisted) identified two issues with the original always-mounted approach:
1. **MapLibre init in hidden container** — initializing WebGL in a `display: none` div can produce a 0×0 canvas
2. **Unnecessary startup cost** — mounting all 3 expensive pages at startup even if the user never visits them

Lazy keep-alive solves both: pages only mount when first visited (always visible at that point), then stay alive.

## Test plan

- [ ] Switch between all tabs rapidly — no flashing, no data reload on return
- [ ] Set filters on DetectionsPage, switch away and back — filters preserved
- [ ] Open MapPage, zoom/pan, switch away and back — viewport preserved
- [ ] Run an analysis — auto-switch to detections tab works correctly
- [ ] `task lint` passes (0 errors)
- [ ] `electron-vite build` succeeds