### PR TITLE
Extract DatePicker component from AnalysisPage

### DIFF
--- a/src/renderer/src/lib/components/DatePicker.svelte
+++ b/src/renderer/src/lib/components/DatePicker.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { ChevronLeft, ChevronRight } from '@lucide/svelte';
   import * as m from '$paraglide/messages';
+  import { parseLocalDate } from '$lib/utils/format';
 
   const {
     value,
@@ -11,12 +12,6 @@
     onchange: (date: string) => void;
     onclose: () => void;
   } = $props();
-
-  /** Parse YYYY-MM-DD as local date (avoids UTC midnight shift). */
-  function parseLocalDate(iso: string): Date {
-    const [y, m, d] = iso.split('-').map(Number);
-    return new Date(y, m - 1, d);
-  }
 
   function getInitialCalendar(val: string) {
     const d = val ? parseLocalDate(val) : new Date();

--- a/src/renderer/src/lib/utils/format.ts
+++ b/src/renderer/src/lib/utils/format.ts
@@ -27,8 +27,14 @@ export function formatTime(seconds: number): string {
 }
 
 export function formatDate(dateStr: string): string {
-  const d = new Date(dateStr);
+  const d = parseLocalDate(dateStr);
   return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+/** Parse YYYY-MM-DD as local date (avoids UTC midnight shift from new Date()). */
+export function parseLocalDate(iso: string): Date {
+  const [y, m, d] = iso.split('-').map(Number);
+  return new Date(y, m - 1, d);
 }
 
 export function formatNumber(n: number): string {

--- a/src/renderer/src/pages/AnalysisPage.svelte
+++ b/src/renderer/src/pages/AnalysisPage.svelte
@@ -24,7 +24,7 @@
     getLocations,
     scanSource,
   } from '$lib/utils/ipc';
-  import { parseRecordingStart } from '$lib/utils/format';
+  import { parseLocalDate, parseRecordingStart } from '$lib/utils/format';
   import type { AvailableModel, InstalledModel, Location, SourceScanResult } from '$shared/types';
   import { onMount } from 'svelte';
   import * as m from '$paraglide/messages';
@@ -63,12 +63,6 @@
 
   // --- Date picker state ---
   let showDatePicker = $state(false);
-
-  /** Parse YYYY-MM-DD as local date (avoids UTC midnight shift). */
-  function parseLocalDate(iso: string): Date {
-    const [y, m, d] = iso.split('-').map(Number);
-    return new Date(y, m - 1, d);
-  }
 
   const selectedDateObj = $derived(recordingDate ? parseLocalDate(recordingDate) : null);
   const formattedDate = $derived(


### PR DESCRIPTION
## Summary
- Extract inline date picker (~165 lines of state, logic, and markup) from `AnalysisPage.svelte` into a reusable `DatePicker.svelte` component
- Fix pre-existing UTC timezone bug where `new Date('YYYY-MM-DD')` parses as UTC midnight, causing incorrect dates for users west of UTC
- AnalysisPage reduced from ~600 to ~390 lines

## Changes
- **New:** `src/renderer/src/lib/components/DatePicker.svelte` — self-contained date picker with calendar grid, month navigation, manual date input parsing, and modal markup
- **Modified:** `src/renderer/src/pages/AnalysisPage.svelte` — replaced inline date picker with `<DatePicker>` component usage

## Test plan
- [ ] Open date picker from analysis page — same behavior as before
- [ ] Select a date, clear a date, type a date manually — all work
- [ ] Navigate months in calendar — works correctly
- [ ] Today button selects today's date
- [ ] Verify date display is correct for users in negative UTC offset timezones
- [ ] `task lint` passes with 0 errors