### PR TITLE
chore: bump bundled birda CLI version to 1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "author": "Tomi P. Hakala <tphakala@users.noreply.github.com>",
   "license": "CC-BY-NC-SA-4.0",
   "birdaCli": {
-    "version": "1.6.2",
+    "version": "1.7.0",
     "repo": "tphakala/birda"
   },
   "build": {


### PR DESCRIPTION
## Summary
- Bumps `birdaCli.version` in package.json from `1.6.2` to `1.7.0`
- v1.7.0 is the first birda release containing embed artifacts, enabling the prebuild script from #55 to successfully download the CLI binary

## Test plan
- [ ] Verify `npm run prebuild` downloads the v1.7.0 embed artifact successfully
- [ ] Verify CI lint/build passes (prebuild was 404-ing on v1.6.2)