### PR TITLE
feat: virtualize annotation box overlay and unify transient toasts

### DIFF
--- a/src/renderer/src/App.svelte
+++ b/src/renderer/src/App.svelte
@@ -6,6 +6,7 @@
   import SetupWizard from '$lib/components/SetupWizard.svelte';
   import LicenseViewer from '$lib/components/LicenseViewer.svelte';
   import AnnotationEditor from '$lib/components/AnnotationEditor.svelte';
+  import ToastOutlet from '$lib/components/ToastOutlet.svelte';
   import AnalysisPage from './pages/AnalysisPage.svelte';
   import DetectionsPage from './pages/DetectionsPage.svelte';
   import MapPage from './pages/MapPage.svelte';
@@ -267,3 +268,4 @@
 
 <LicenseViewer bind:open={showLicenses} />
 <AnnotationEditor />
+<ToastOutlet />

--- a/src/renderer/src/lib/components/AnnotationEditor.svelte
+++ b/src/renderer/src/lib/components/AnnotationEditor.svelte
@@ -40,6 +40,8 @@
   // Viewport state drives box geometry. Bumped via reactive reassignment to retrigger $derived.
   let pxPerSecond = $state(1);
   let scrollLeft = $state(0);
+  /** Visible pane width in px; only changes on window resize, so updated from the ResizeObserver/ready, not on scroll. */
+  let viewportWidth = $state(0);
 
   let resizeObserver: ResizeObserver | null = null;
 
@@ -48,6 +50,30 @@
     scrollLeft,
     freqMax,
     height: spectrogramHeight,
+  });
+
+  /** Render a little beyond the pane so scrolling does not flash empty boxes at the edges. */
+  const OVERSCAN_PX = 200;
+
+  // Virtualize: render only boxes whose projected x-range intersects the visible pane (plus the
+  // selected/dragged box). Derived from `viewport`, so it stays aligned under scroll/zoom/freqMax/resize.
+  const visibleBoxes = $derived.by(() => {
+    const pps = viewport.pxPerSecond;
+    const sl = viewport.scrollLeft;
+    const vw = viewportWidth;
+    // Pre-'ready' the scale is still the reset default, so geometry is not valid yet: render nothing
+    // rather than boxes at the wrong scale (loading flips to false in the wavesurfer 'ready' handler).
+    if (loading || vw <= 0 || pps <= 0) return [];
+    const selected = annotationEditor.selectedKey;
+    const minX = -OVERSCAN_PX;
+    const maxX = vw + OVERSCAN_PX;
+    return annotationEditor.boxes.filter((box) => {
+      // Keep the selected box rendered even off-screen: it is always the box being moved/resized.
+      if (box.key === selected) return true;
+      const left = box.start_time * pps - sl;
+      const right = left + Math.max(1, (box.end_time - box.start_time) * pps);
+      return right >= minX && left <= maxX;
+    });
   });
 
   let zoomPxPerSec = 0; // 0 => fit to width
@@ -65,6 +91,16 @@
     // does not scroll natively; mirror wavesurfer's horizontal scroll onto it.
     const pluginWrapper = spectrogramEl?.firstElementChild;
     if (pluginWrapper instanceof HTMLElement) pluginWrapper.scrollLeft = scrollLeft;
+  }
+
+  /**
+   * Update the cached visible pane width. Kept out of refreshViewport (which fires on every scroll
+   * tick and writes scrollLeft just above): reading clientWidth right after a layout write forces a
+   * synchronous reflow per frame. Width only changes on window resize, so this runs from the
+   * ResizeObserver and the 'ready' handler instead.
+   */
+  function updateViewportWidth(): void {
+    viewportWidth = overlayEl?.clientWidth ?? 0;
   }
 
   /**
@@ -92,6 +128,11 @@
     initializing = true;
     loading = true;
     loadError = null;
+    // Reset viewport scale for the new file; 'ready' and the ResizeObserver re-establish it.
+    pxPerSecond = 1;
+    scrollLeft = 0;
+    viewportWidth = 0;
+    duration = 0;
 
     let settings;
     try {
@@ -136,6 +177,7 @@
       duration = wavesurfer.getDuration();
       ensureSpectrogramMount();
       refreshViewport();
+      updateViewportWidth();
     });
     wavesurfer.on('play', () => {
       playing = true;
@@ -165,6 +207,8 @@
     // ResizeObserver: window resize changes effective px-per-second without a wavesurfer event.
     resizeObserver?.disconnect();
     resizeObserver = new ResizeObserver(() => {
+      // Read width before refreshViewport's scrollLeft write to avoid a read-after-write reflow.
+      updateViewportWidth();
       refreshViewport();
     });
     resizeObserver.observe(waveformEl);
@@ -477,7 +521,7 @@
               aria-label={m.annotation_overlay_label()}
               onpointerdown={handleOverlayPointerDown}
             >
-              {#each annotationEditor.boxes as box (box.key)}
+              {#each visibleBoxes as box (box.key)}
                 <AnnotationBox
                   {box}
                   rect={annotationToRect(box, viewport)}
@@ -505,12 +549,6 @@
         <AnnotationSidePanel />
       </div>
     </div>
-
-    {#if annotationEditor.toast}
-      <div class="toast toast-end">
-        <div class="alert alert-error text-sm">{annotationEditor.toast}</div>
-      </div>
-    {/if}
   </div>
 {/if}
 

--- a/src/renderer/src/lib/components/AnnotationEditor.svelte
+++ b/src/renderer/src/lib/components/AnnotationEditor.svelte
@@ -176,8 +176,9 @@
       loading = false;
       duration = wavesurfer.getDuration();
       ensureSpectrogramMount();
-      refreshViewport();
+      // Read width before refreshViewport's scrollLeft write to avoid a read-after-write reflow.
       updateViewportWidth();
+      refreshViewport();
     });
     wavesurfer.on('play', () => {
       playing = true;

--- a/src/renderer/src/lib/components/SourceFilesPanel.svelte
+++ b/src/renderer/src/lib/components/SourceFilesPanel.svelte
@@ -21,6 +21,7 @@
   import type { SourceScanResult, FileCompletedPayload } from '$shared/types';
   import * as m from '$paraglide/messages';
   import { openAnnotationEditor } from '$lib/stores/annotation.svelte';
+  import { showToast } from '$lib/stores/toast.svelte';
   import { resolveAnnotationFile } from '$lib/utils/ipc';
   import { appState } from '$lib/stores/app.svelte';
 
@@ -66,25 +67,6 @@
     return 0;
   }
 
-  const ANNOTATE_HINT_TIMEOUT_MS = 4000;
-  let annotateHint = $state<string | null>(null);
-
-  // Auto-dismiss the hint. The effect re-runs whenever the message changes and
-  // its cleanup clears the pending timer (and also runs on unmount).
-  $effect(() => {
-    if (annotateHint === null) return;
-    const timer = setTimeout(() => {
-      annotateHint = null;
-    }, ANNOTATE_HINT_TIMEOUT_MS);
-    return () => {
-      clearTimeout(timer);
-    };
-  });
-
-  function showAnnotateHint(message: string): void {
-    annotateHint = message;
-  }
-
   async function annotate(filePath: string): Promise<void> {
     const runId = appState.selectedRunId ?? appState.lastRunId ?? null;
     try {
@@ -93,11 +75,11 @@
         openAnnotationEditor(id, filePath);
       } else {
         // No analyzed audio_file row exists for this path yet; annotation needs an analysis run first.
-        showAnnotateHint(m.sourceFiles_annotateNotAnalyzed());
+        showToast(m.sourceFiles_annotateNotAnalyzed(), { severity: 'warning' });
       }
     } catch (err) {
       console.error('Failed to resolve audio file for annotation:', err);
-      showAnnotateHint(m.sourceFiles_annotateNotAnalyzed());
+      showToast(m.sourceFiles_annotateNotAnalyzed(), { severity: 'warning' });
     }
   }
 </script>
@@ -293,13 +275,5 @@
     <FolderOpen size={32} />
     <p class="text-sm">{m.sourceFiles_noAudioFiles()}</p>
     <p class="text-xs">{m.sourceFiles_supportedFormats()}</p>
-  </div>
-{/if}
-
-{#if annotateHint}
-  <div class="toast toast-end toast-bottom z-50">
-    <div class="alert alert-warning">
-      <span>{annotateHint}</span>
-    </div>
   </div>
 {/if}

--- a/src/renderer/src/lib/components/ToastOutlet.svelte
+++ b/src/renderer/src/lib/components/ToastOutlet.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import { X } from '@lucide/svelte';
+  import { toast, dismissToast } from '$lib/stores/toast.svelte';
+  import * as m from '$paraglide/messages';
+
+  // z-[100] so the single fixed outlet sits above the z-50 annotation editor modal.
+  const severityClass = $derived(
+    toast.severity === 'error'
+      ? 'alert-error'
+      : toast.severity === 'warning'
+        ? 'alert-warning'
+        : toast.severity === 'success'
+          ? 'alert-success'
+          : 'alert-info',
+  );
+</script>
+
+{#if toast.message}
+  <div class="toast toast-end toast-bottom z-[100]">
+    <div role="alert" class="alert {severityClass} text-sm">
+      <span>{toast.message}</span>
+      <button
+        type="button"
+        class="btn btn-ghost btn-xs btn-circle"
+        onclick={dismissToast}
+        aria-label={m.common_button_close()}
+      >
+        <X size={14} />
+      </button>
+    </div>
+  </div>
+{/if}

--- a/src/renderer/src/lib/stores/annotation.svelte.ts
+++ b/src/renderer/src/lib/stores/annotation.svelte.ts
@@ -1,6 +1,7 @@
 import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 import type { Annotation, AnnotationInput, AnnotationSource } from '$shared/types';
 import { listAnnotations, upsertAnnotation, deleteAnnotation, getDetections, resolveAllLabels } from '$lib/utils/ipc';
+import { showToast } from '$lib/stores/toast.svelte';
 
 /** A box in the editor: either a persisted annotation or an unsaved AI suggestion. */
 export interface EditorBox {
@@ -29,11 +30,9 @@ interface AnnotationEditorState {
   selectedKey: string | null;
   loading: boolean;
   error: string | null;
-  toast: string | null;
 }
 
 const MAX_DETECTION_SUGGESTIONS = 5000;
-const TOAST_DURATION_MS = 4000;
 
 export const annotationEditor = $state<AnnotationEditorState>({
   open: false,
@@ -43,10 +42,8 @@ export const annotationEditor = $state<AnnotationEditorState>({
   selectedKey: null,
   loading: false,
   error: null,
-  toast: null,
 });
 
-let toastTimer: ReturnType<typeof setTimeout> | null = null;
 let manualBoxSeq = 0;
 /** Keys with a persist in flight; blocks duplicate INSERTs from rapid repeat actions on the same box. */
 const persistInFlight = new SvelteSet<string>();
@@ -64,7 +61,6 @@ export function openAnnotationEditor(audioFileId: number, filePath: string): voi
   annotationEditor.boxes = [];
   annotationEditor.selectedKey = null;
   annotationEditor.error = null;
-  clearToast();
   void loadBoxes();
 }
 
@@ -76,7 +72,6 @@ export function closeAnnotationEditor(): void {
   annotationEditor.selectedKey = null;
   annotationEditor.error = null;
   annotationEditor.loading = false;
-  clearToast();
 }
 
 function annotationToBox(a: Annotation, commonName: string): EditorBox {
@@ -152,23 +147,6 @@ async function loadBoxes(): Promise<void> {
   }
 }
 
-function clearToast(): void {
-  if (toastTimer !== null) {
-    clearTimeout(toastTimer);
-    toastTimer = null;
-  }
-  annotationEditor.toast = null;
-}
-
-function showToast(message: string): void {
-  if (toastTimer !== null) clearTimeout(toastTimer);
-  annotationEditor.toast = message;
-  toastTimer = setTimeout(() => {
-    annotationEditor.toast = null;
-    toastTimer = null;
-  }, TOAST_DURATION_MS);
-}
-
 function inputFromBox(box: EditorBox, audioFileId: number, status: AnnotationInput['status']): AnnotationInput {
   return {
     ...(box.annotationId !== null ? { id: box.annotationId } : {}),
@@ -223,7 +201,7 @@ async function persistBox(box: EditorBox): Promise<void> {
       annotationEditor.boxes = annotationEditor.boxes.filter((b) => b.key !== box.key);
       if (annotationEditor.selectedKey === box.key) annotationEditor.selectedKey = null;
     }
-    showToast(errorMessage(err));
+    showToast(errorMessage(err), { severity: 'error' });
   } finally {
     persistInFlight.delete(box.key);
     if (pendingPersistKeys.delete(box.key)) {
@@ -322,6 +300,6 @@ export async function removeBox(key: string): Promise<void> {
   } catch (err) {
     // Re-insert only the removed box so concurrent edits to other boxes survive.
     annotationEditor.boxes = [...annotationEditor.boxes, removed].sort((a, b) => a.start_time - b.start_time);
-    showToast(errorMessage(err));
+    showToast(errorMessage(err), { severity: 'error' });
   }
 }

--- a/src/renderer/src/lib/stores/toast.svelte.ts
+++ b/src/renderer/src/lib/stores/toast.svelte.ts
@@ -1,0 +1,38 @@
+/** Severity drives the daisyUI alert color in ToastOutlet. */
+type ToastSeverity = 'error' | 'warning' | 'info' | 'success';
+
+interface ToastState {
+  message: string | null;
+  severity: ToastSeverity;
+}
+
+const DEFAULT_TOAST_DURATION_MS = 4000;
+
+/** Single app-wide transient toast. Rendered once by ToastOutlet at the app root. */
+export const toast = $state<ToastState>({ message: null, severity: 'info' });
+
+let toastTimer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Show a transient toast, replacing any current one. Callable from non-component
+ * contexts (e.g. store actions), so the auto-dismiss timer lives at module scope
+ * rather than in a component $effect. Re-entrant calls restart the timer.
+ */
+export function showToast(message: string, options?: { severity?: ToastSeverity; durationMs?: number }): void {
+  if (toastTimer !== null) clearTimeout(toastTimer);
+  toast.message = message;
+  toast.severity = options?.severity ?? 'info';
+  toastTimer = setTimeout(() => {
+    toast.message = null;
+    toastTimer = null;
+  }, options?.durationMs ?? DEFAULT_TOAST_DURATION_MS);
+}
+
+/** Dismiss the current toast immediately. Clears the pending timer first so it cannot null a toast shown later. */
+export function dismissToast(): void {
+  if (toastTimer !== null) {
+    clearTimeout(toastTimer);
+    toastTimer = null;
+  }
+  toast.message = null;
+}


### PR DESCRIPTION
## Summary

Two focused improvements to the spectrogram annotation editor, batched because they share `AnnotationEditor.svelte`.

### 1. Virtualize the annotation-box overlay
The editor rendered every annotation/suggestion box (up to 5000) as a live, absolutely-positioned DOM node, and recomputed all of their pixel rects on every scroll/zoom tick. On dense recordings this is O(N) per frame and causes scroll/zoom jank.

Now only the boxes whose projected x-range intersects the visible spectrogram pane are rendered (with a small overscan), plus the currently selected box (which is always the one being moved/resized). The visible set is a `$derived` computed from the same `viewport` signal that positions the rects, so boxes stay pixel-aligned with the waveform under scroll, zoom, frequency-max, and resize with no separate geometry snapshot. `viewportWidth` is sourced from the `ResizeObserver` and the wavesurfer `ready` handler rather than from `refreshViewport`, to avoid a read-after-write layout reflow on every scroll tick.

At fit-to-width zoom every box is genuinely on screen, so windowing renders them all once (a bounded, one-time layout cost, not per-frame); the per-frame hot path is the zoomed-in scroll/pan case, which windowing eliminates.

### 2. Unify the transient toasts
There were two independent auto-dismiss toast implementations: an editor-scoped one in the annotation store (rendered inside the modal) and a component-local hint in `SourceFilesPanel`, each duplicating the same 4000ms timer pattern at a different scope and severity.

Both are replaced by a single shared toast store (`stores/toast.svelte.ts`: `showToast(message, { severity?, durationMs? })` + `dismissToast()`) and one app-root outlet (`ToastOutlet.svelte`). The outlet carries severity (error/warning/info/success), supports click-to-dismiss, and sits above the editor modal, so a persist-failure toast issued by an in-flight save now stays visible even after the editor closes (previously it was set on a field whose outlet lived inside the closed modal and was silently lost).

No database, IPC, or birda CLI changes. No new i18n keys.

## Test plan
- [ ] `task lint` (ESLint + svelte-check + tsc), `task build`, `knip`, and `npm run validate:translations` pass.
- [ ] Open a recording with many detections: boxes stay aligned with the spectrogram under zoom, horizontal scroll, and window resize.
- [ ] Select a box near the pane edge and scroll: the selected box stays editable; move/resize/draw/accept/remove all work.
- [ ] Force a persist failure: a single error toast appears, can be dismissed by click, and auto-dismisses; it remains visible if the editor is closed mid-save.
- [ ] Trigger the "analyze before annotating" path from the source-file list: the same outlet renders it with warning styling, above the editor when open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a unified notification system for consistent feedback across the app when errors or warnings occur.

* **Performance Improvements**
  * Optimized annotation editor rendering by displaying only visible boxes in the viewport, improving performance when working with large annotation sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->