### PR TITLE
chore(deps): upgrade typescript to 6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "svelte-maplibre-gl": "^1.0.3",
         "tailwindcss": "^4.3.2",
         "tsx": "^4.21.0",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.62.1",
         "vite": "^7.3.1"
       }
@@ -10009,9 +10009,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "svelte-maplibre-gl": "^1.0.3",
     "tailwindcss": "^4.3.2",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.62.1",
     "vite": "^7.3.1"
   },

--- a/src/renderer/src/assets.d.ts
+++ b/src/renderer/src/assets.d.ts
@@ -12,3 +12,5 @@ declare module '*.jpg' {
   const src: string;
   export default src;
 }
+
+declare module '*.css';


### PR DESCRIPTION
## Summary
- Upgrade typescript 5.9.3 to 6.0.3
- Fix new TS2882 diagnostic (side-effect import lacking type declarations) by adding a `*.css` module declaration to `assets.d.ts`

## Test Plan
- [x] `npm run validate` (format, lint, typecheck, translations) passes
- [x] `task build` succeeds
- [x] `npm audit` reports 0 vulnerabilities