### PR TITLE
chore(deps): upgrade electron to 43.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@tsconfig/svelte": "^5.0.7",
         "@types/better-sqlite3": "^7.6.13",
         "@types/suncalc": "^1.9.2",
-        "electron": "^41.1.1",
+        "electron": "^43.0.0",
         "electron-builder": "^26.7.0",
         "electron-vite": "^5.0.0",
         "eslint": "^10.0.2",
@@ -5031,11 +5031,10 @@
       }
     },
     "node_modules/electron": {
-      "version": "41.9.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.9.0.tgz",
-      "integrity": "sha512-i1tQNY3Zbc8KXvsXYrada3G5F0v87ZKCeWy5M+hlSGECOCtMWGcAjMZePl5j2deqHEA5Int3qzCgF3lcFKK1vQ==",
+      "version": "43.0.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.0.0.tgz",
+      "integrity": "sha512-PV60GsWU6qufhuOhw3n+Yix3WPDcqDtBqE8orbEQGQGHEkgp9o/JCPgb7L4vIL0r1HnfPdqSRtboOTqbDkcFDQ==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron-internal/extract-zip": "^1.0.1",
@@ -5043,7 +5042,8 @@
         "@types/node": "^24.9.0"
       },
       "bin": {
-        "electron": "cli.js"
+        "electron": "cli.js",
+        "install-electron": "install.js"
       },
       "engines": {
         "node": ">= 22.12.0"

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@tsconfig/svelte": "^5.0.7",
     "@types/better-sqlite3": "^7.6.13",
     "@types/suncalc": "^1.9.2",
-    "electron": "^41.1.1",
+    "electron": "^43.0.0",
     "electron-builder": "^26.7.0",
     "electron-vite": "^5.0.0",
     "eslint": "^10.0.2",


### PR DESCRIPTION
## Summary
- Upgrade electron 41.9.0 to 43.0.0
- Rebuild better-sqlite3 native module for the new Electron ABI (`task rebuild`)

## Test Plan
- [x] `npm run validate` (format, lint, typecheck, translations) passes
- [x] `task build` succeeds
- [x] App launched under Xvfb: DB migrations ran cleanly, IPC handlers responded correctly
- [x] `npm audit` reports 0 vulnerabilities