### PR TITLE
chore(deps): upgrade prettier-plugin-svelte to 4.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "lint-staged": "^17.0.8",
         "maplibre-gl": "^5.17.0",
         "prettier": "^3.9.4",
-        "prettier-plugin-svelte": "^3.4.1",
+        "prettier-plugin-svelte": "^4.1.1",
         "prettier-plugin-tailwindcss": "^0.7.2",
         "svelte": "^5.53.5",
         "svelte-check": "^4.3.6",
@@ -8235,14 +8235,17 @@
       }
     },
     "node_modules/prettier-plugin-svelte": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.5.2.tgz",
-      "integrity": "sha512-ItFouLvzSFE3ulNl4DKoWM3BGcbDCNVpIyy/Y3F2gC3aNiGLxtFUdffVqO5Z5hhYG+DFT5KULWaxmeFFpdbvaQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-4.1.1.tgz",
+      "integrity": "sha512-wXvbXMjSvb4C9ENWTHXyd+ihakKCsJ6rJhLP6/8HFNj4GkZr48jqL9PoKsl2sk7SyCZRTnJ7O2TTowUpOxP/KA==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
       "peerDependencies": {
         "prettier": "^3.0.0",
-        "svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
+        "svelte": "^5.0.0"
       }
     },
     "node_modules/prettier-plugin-tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "lint-staged": "^17.0.8",
     "maplibre-gl": "^5.17.0",
     "prettier": "^3.9.4",
-    "prettier-plugin-svelte": "^3.4.1",
+    "prettier-plugin-svelte": "^4.1.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "svelte": "^5.53.5",
     "svelte-check": "^4.3.6",


### PR DESCRIPTION
## Summary
- Upgrade prettier-plugin-svelte 3.5.2 to 4.1.1
- No code reformatting needed, existing files already match the new output style
- Confirmed `.prettierrc` doesn't reference the removed `svelteStrictMode`/`svelteBracketNewLine` options

## Test Plan
- [x] `npm run format:check` passes (no diff produced by `prettier --write .`)
- [x] `npm run lint`, `npm run typecheck` pass
- [x] `npm audit` reports 0 vulnerabilities