### PR TITLE
chore(deps): upgrade suncalc to 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "better-sqlite3": "^12.6.2",
         "daisyui": "^5.6.6",
         "music-metadata": "^11.12.3",
-        "suncalc": "^1.9.0",
+        "suncalc": "^2.0.0",
         "wavesurfer.js": "^7.12.1",
         "zod": "^4.3.6"
       },
@@ -28,7 +28,6 @@
         "@tailwindcss/vite": "^4.3.2",
         "@tsconfig/svelte": "^5.0.7",
         "@types/better-sqlite3": "^7.6.13",
-        "@types/suncalc": "^1.9.2",
         "electron": "^43.0.0",
         "electron-builder": "^26.7.0",
         "electron-vite": "^5.0.0",
@@ -3393,13 +3392,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/suncalc": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@types/suncalc/-/suncalc-1.9.2.tgz",
-      "integrity": "sha512-ATAGBHHfA1TlE2tjfidLyTcysjoT2JHHEAmWRULh73SU9UTn++j5fqHEW16X6Y/2Li87jEQXzgu4R/OOdlDqzw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -9109,9 +9101,9 @@
       }
     },
     "node_modules/suncalc": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/suncalc/-/suncalc-1.9.0.tgz",
-      "integrity": "sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/suncalc/-/suncalc-2.0.0.tgz",
+      "integrity": "sha512-RcO28GOMXNnB+sr+c7/+zv5UPMa9wxIsUVGE3HddjQykqCVEC2rc4t4IjBB7qaa7K7dx5Cxp8UZwexyXrX8JkA=="
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "better-sqlite3": "^12.6.2",
     "daisyui": "^5.6.6",
     "music-metadata": "^11.12.3",
-    "suncalc": "^1.9.0",
+    "suncalc": "^2.0.0",
     "wavesurfer.js": "^7.12.1",
     "zod": "^4.3.6"
   },
@@ -125,7 +125,6 @@
     "@tailwindcss/vite": "^4.3.2",
     "@tsconfig/svelte": "^5.0.7",
     "@types/better-sqlite3": "^7.6.13",
-    "@types/suncalc": "^1.9.2",
     "electron": "^43.0.0",
     "electron-builder": "^26.7.0",
     "electron-vite": "^5.0.0",

--- a/src/renderer/src/lib/utils/sun.ts
+++ b/src/renderer/src/lib/utils/sun.ts
@@ -16,10 +16,8 @@ interface HourlySunPhase {
   gradient?: SunPhaseGradient;
 }
 
-const RAD_TO_DEG = 180 / Math.PI;
-
 function altitudeDeg(date: Date, latitude: number, longitude: number): number {
-  return getPosition(date, latitude, longitude).altitude * RAD_TO_DEG;
+  return getPosition(date, latitude, longitude).altitude;
 }
 
 /** Classify by sun altitude: >= 0° daylight, >= -6° twilight (civil), < -6° night. */


### PR DESCRIPTION
## Summary
- Upgrade suncalc 1.9.0 to 2.0.0
- suncalc 2 returns `altitude` in degrees directly (was radians in v1), so drop the manual `RAD_TO_DEG` conversion in `sun.ts`
- Drop the now-redundant `@types/suncalc` devDependency; suncalc 2 ships its own type declarations
- `azimuth` is unused in this codebase, so v2's reference-frame change (south-based to north-based clockwise) has no effect here

## Test Plan
- [x] Verified suncalc 2's `getPosition` returns sensible degree values (~67° at equatorial noon, ~-66° at midnight)
- [x] `npm run lint`, `npm run typecheck`, `npm run format:check` pass
- [x] `npm audit` reports 0 vulnerabilities