### PR TITLE
chore(deps): upgrade svelte-maplibre-gl to 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "prettier-plugin-tailwindcss": "^0.7.2",
         "svelte": "^5.53.5",
         "svelte-check": "^4.3.6",
-        "svelte-maplibre-gl": "^1.0.3",
+        "svelte-maplibre-gl": "^2.0.1",
         "tailwindcss": "^4.3.2",
         "tsx": "^4.21.0",
         "typescript": "^6.0.3",
@@ -9251,13 +9251,13 @@
       }
     },
     "node_modules/svelte-maplibre-gl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/svelte-maplibre-gl/-/svelte-maplibre-gl-1.0.3.tgz",
-      "integrity": "sha512-pGZMLN5EcJoe6lREyaY2lsbkvrnKjIGHJRM2ijN+TUDeJbV9oecjBxbDXQZd8b5X4JJztSG915L731dFdhhSwA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/svelte-maplibre-gl/-/svelte-maplibre-gl-2.0.1.tgz",
+      "integrity": "sha512-94IjndWargdn4ZUncLxn671LZgOPf2kAC46u0pRvOm3780V3Sw/L5ca+a+8DthghdSMXWlng06IMzrlt49pzKw==",
       "dev": true,
       "license": "(MIT OR Apache-2.0)",
       "peerDependencies": {
-        "maplibre-gl": "^5.0.0 || ^4.0.0",
+        "maplibre-gl": ">=6.0.0-0 || ^5.19.0",
         "svelte": ">=5.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "prettier-plugin-tailwindcss": "^0.7.2",
     "svelte": "^5.53.5",
     "svelte-check": "^4.3.6",
-    "svelte-maplibre-gl": "^1.0.3",
+    "svelte-maplibre-gl": "^2.0.1",
     "tailwindcss": "^4.3.2",
     "tsx": "^4.21.0",
     "typescript": "^6.0.3",


### PR DESCRIPTION
## Summary
- Upgrade svelte-maplibre-gl 1.0.3 to 2.0.1
- Per upstream changesets, the only breaking change is a narrower `maplibre-gl` peer requirement (`>=5.19.0`, dropping 4.x support); this project already runs `maplibre-gl@5.24.0`, so no code changes needed
- The 2.0.0 `padding` prop behavior change doesn't apply since this codebase never sets that prop

## Test Plan
- [x] `npm run lint`, `npm run typecheck`, `npm run format:check` pass
- [x] `task build` succeeds
- [x] App launched under Xvfb with no maplibre-related errors
- [x] `npm audit` reports 0 vulnerabilities