### PR TITLE
chore(deps): upgrade prettier-plugin-tailwindcss to 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "maplibre-gl": "^5.17.0",
         "prettier": "^3.9.4",
         "prettier-plugin-svelte": "^4.1.1",
-        "prettier-plugin-tailwindcss": "^0.7.2",
+        "prettier-plugin-tailwindcss": "^0.8.0",
         "svelte": "^5.53.5",
         "svelte-check": "^4.3.6",
         "svelte-maplibre-gl": "^2.0.1",
@@ -8241,9 +8241,9 @@
       }
     },
     "node_modules/prettier-plugin-tailwindcss": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.7.4.tgz",
-      "integrity": "sha512-UKii4RjY05SNt/WQi6/NcOn/LsT0/ILLXsxygjbRg5/YZelsSu5jTqorYHPDGq4nZy5q5hpCu+XdGZ1xaJEQgw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.8.0.tgz",
+      "integrity": "sha512-V8ITGH87yuBDF6JpEZTOVlUz/saAwqb8f3HRgUj8Lh+tGCcrmorhsLpYqzygwFwK0PE2Ib6Mv3M7T/uE2tZV1g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "maplibre-gl": "^5.17.0",
     "prettier": "^3.9.4",
     "prettier-plugin-svelte": "^4.1.1",
-    "prettier-plugin-tailwindcss": "^0.7.2",
+    "prettier-plugin-tailwindcss": "^0.8.0",
     "svelte": "^5.53.5",
     "svelte-check": "^4.3.6",
     "svelte-maplibre-gl": "^2.0.1",


### PR DESCRIPTION
## Summary
- Upgrade prettier-plugin-tailwindcss 0.7.4 to 0.8.0
- No reformatting needed

## Test Plan
- [x] `npm run format:check`, `npm run lint`, `npm run typecheck` pass
- [x] `npm audit` reports 0 vulnerabilities