### PR TITLE
fix: treat a locked file status as a skip, not a failure

### DIFF
--- a/shared/types.ts
+++ b/shared/types.ts
@@ -399,7 +399,9 @@ export interface ProgressPayload {
 
 export interface FileCompletedPayload {
   file: string;
-  status: 'processed' | 'failed' | 'skipped';
+  // 'locked' means another worker held the per-file lock, so birda skipped the
+  // file rather than failing it (birda's FileStatus::Locked). Treat it as a skip.
+  status: 'processed' | 'failed' | 'skipped' | 'locked';
   detections: number;
   duration_ms: number;
 }

--- a/src/main/ipc/analysis.ts
+++ b/src/main/ipc/analysis.ts
@@ -348,12 +348,16 @@ export function registerAnalysisHandlers(): void {
                   } finally {
                     importSemaphore.release();
                   }
-                } else if (payload.status === 'skipped') {
+                } else if (payload.status === 'skipped' || payload.status === 'locked') {
+                  // A locked file was claimed by another worker in a distributed
+                  // run; birda reports it as a skip, not a failure, so count it
+                  // as one here too rather than inflating the failed total.
                   skippedFileCount++;
                   if (trackFileWithOverflow(win, skippedFiles, payload.file, skippedFilesOverflow, 'skipped')) {
                     skippedFilesOverflow = true;
                   }
-                  sendLog(win, 'info', 'analysis', `Skipped ${payload.file}`);
+                  const reason = payload.status === 'locked' ? 'Locked by another worker, skipped' : 'Skipped';
+                  sendLog(win, 'info', 'analysis', `${reason} ${payload.file}`);
                 } else {
                   // Must be 'failed' - only remaining case
                   failedFileCount++;

--- a/src/renderer/src/lib/components/SourceFilesPanel.svelte
+++ b/src/renderer/src/lib/components/SourceFilesPanel.svelte
@@ -44,7 +44,11 @@
     for (const evt of analysisState.events) {
       if (evt.event === 'file_completed') {
         const p = evt.payload as FileCompletedPayload;
-        statuses.set(p.file, p.status === 'processed' ? 'completed' : p.status);
+        // A 'locked' file was skipped because another worker held it; render it
+        // as a skip. 'processed' maps to the panel's 'completed' state.
+        const status: FileStatus =
+          p.status === 'processed' ? 'completed' : p.status === 'locked' ? 'skipped' : p.status;
+        statuses.set(p.file, status);
       }
     }
 


### PR DESCRIPTION
## What

birda emits a `file_completed` event whose `status` can be `locked` when another concurrent worker held the per-file lock. That is a skip, not a failure (birda's `FileStatus::Locked`), but the GUI's `FileCompletedPayload.status` union omitted `locked`, so the main-process handler's `else` branch (commented "must be 'failed'") counted a locked file as a failure, and the source-files panel had no render case for it and rendered it blank. The result: an all-locked distributed run that the CLI reports as success with those files skipped showed up as **failed** in the GUI.

The gap is pre-existing (the early advisory-skip path already emitted `locked`), but it became common with the birda-side change that stopped miscounting a lock lost to the check-to-use race as an error (tphakala/birda#354).

## How

- `shared/types.ts`: add `locked` to the `FileCompletedPayload.status` union, so the wire type matches what the CLI actually emits.
- `src/main/ipc/analysis.ts`: treat `locked` as a skip in the file-completion counting, so it increments the skipped total rather than the failed total, and the `else` genuinely remains only `failed`.
- `src/renderer/src/lib/components/SourceFilesPanel.svelte`: map `locked` to the panel's existing `skipped` state, so no new i18n key or render branch is needed.

The renderer progress store already only increments `filesFailed` on `failed`, so a locked file was never counted as failed there.

## Test plan

- [x] `npm run typecheck` (tsc strict, both tsconfigs)
- [x] `npm run check` (svelte-check: 0 errors, 0 warnings)
- [x] eslint on the changed files: clean
- [x] prettier: unchanged
